### PR TITLE
fix: MUST have label names sorted in lexicographical order

### DIFF
--- a/promremote/client.go
+++ b/promremote/client.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -275,6 +276,11 @@ func (t TSList) toPromWriteRequest() *prompb.WriteRequest {
 
 	for i, ts := range t {
 		labels := make([]prompb.Label, len(ts.Labels))
+
+		sort.Slice(ts.Labels, func(i, j int) bool {
+			return ts.Labels[i].Name < ts.Labels[j].Name
+		})
+
 		for j, label := range ts.Labels {
 			labels[j] = prompb.Label{Name: label.Name, Value: label.Value}
 		}

--- a/promremote/client_test.go
+++ b/promremote/client_test.go
@@ -68,12 +68,18 @@ func TestPromRemoteClientWrite(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Len(t, newWR.Timeseries, 1)
-		assert.Len(t, newWR.Timeseries[0].Labels, 2)
+		assert.Len(t, newWR.Timeseries[0].Labels, 5)
 		assert.Len(t, newWR.Timeseries[0].Samples, 1)
 		assert.Equal(t, "__name__", newWR.Timeseries[0].Labels[0].Name)
-		assert.Equal(t, "foo_bar", newWR.Timeseries[0].Labels[0].Value)
-		assert.Equal(t, "biz", newWR.Timeseries[0].Labels[1].Name)
-		assert.Equal(t, "baz", newWR.Timeseries[0].Labels[1].Value)
+		assert.Equal(t, "my name", newWR.Timeseries[0].Labels[0].Value)
+		assert.Equal(t, "bar", newWR.Timeseries[0].Labels[1].Name)
+		assert.Equal(t, "my bar", newWR.Timeseries[0].Labels[1].Value)
+		assert.Equal(t, "baz", newWR.Timeseries[0].Labels[2].Name)
+		assert.Equal(t, "my baz", newWR.Timeseries[0].Labels[2].Value)
+		assert.Equal(t, "biz", newWR.Timeseries[0].Labels[3].Name)
+		assert.Equal(t, "my biz", newWR.Timeseries[0].Labels[3].Value)
+		assert.Equal(t, "foo", newWR.Timeseries[0].Labels[4].Name)
+		assert.Equal(t, "my foo", newWR.Timeseries[0].Labels[4].Value)
 		assert.Equal(t, 1415.92, newWR.Timeseries[0].Samples[0].Value)
 		assert.Equal(t, nowMillis, newWR.Timeseries[0].Samples[0].Timestamp)
 	}))
@@ -92,11 +98,23 @@ func TestPromRemoteClientWrite(t *testing.T) {
 			Labels: []Label{
 				{
 					Name:  "__name__",
-					Value: "foo_bar",
+					Value: "my name",
+				},
+				{
+					Name:  "foo",
+					Value: "my foo",
+				},
+				{
+					Name:  "bar",
+					Value: "my bar",
 				},
 				{
 					Name:  "biz",
-					Value: "baz",
+					Value: "my biz",
+				},
+				{
+					Name:  "baz",
+					Value: "my baz",
 				},
 			},
 			Datapoint: Datapoint{


### PR DESCRIPTION
According to the [Prometheus remote write spec](https://prometheus.io/docs/specs/remote_write_spec/#labelsl), label names MUST be sorted in lexicographical order.

Thanos, for example, does not like it when you don't. 

This PR fixes this. 